### PR TITLE
To string

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ The literal operators are declared in the namespace `nonstd::literals::string_vi
 | to_string()           |>=C++17| template&lt; class CharT, class Traits, class Allocator=std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator&gt;<br>**to_string**( std::basic_string_view&lt;CharT, Traits> v, Allocator const & a=Allocator() );|
 | to_string_view()      |>=C++17| template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );|
 | **`nonstd::string_view`**|&nbsp; | &nbsp;  |
-| to_string()<br>&nbsp;<br>*non-msvc14 (vs2015)* |>=C++98| template&lt; class CharT, class Traits, class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a = Allocator() );|
-| *msvc14 (vs2015)*<br>&nbsp;<br>to_string() |>=C++98|template&lt; class CharT, class Traits ><br>std::basic_string&lt;CharT, Traits><br>**to_string**( basic_string_view&lt;CharT, Traits> v );|
+| to_string()<br>&nbsp;<br>*non-msvc14 (vs2015)* |>=C++11| template&lt; class CharT, class Traits, class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a = Allocator() );|
+| to_string()<br>&nbsp;<br>*msvc14 (vs2015)* |>=C++98|template&lt; class CharT, class Traits ><br>std::basic_string&lt;CharT, Traits><br>**to_string**( basic_string_view&lt;CharT, Traits> v );|
+| to_string()<br>&nbsp;<br>*msvc14 (vs2015)* |>=C++98|template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a );|
 | to_string_view()      |>=C++98| template&lt; class CharT, class Traits, class Allocator ><br>basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );|
 | &nbsp;                |&nbsp; | &nbsp; |
 | **Class methods**     |&nbsp; | macro `nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS` |
@@ -138,6 +139,7 @@ The literal operators are declared in the namespace `nonstd::literals::string_vi
 | Converting operator   |>=C++11| template&lt; class Allocator ><br>explicit **operator std::basic_string**&lt;CharT, Traits, Allocator>() const;|
 | to_string()           |>=C++11| template&lt; class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a = Allocator() ) const;|
 | to_string()           |<C++11 | std::basic_string&lt;CharT, Traits><br>**to_string**() const;|
+| to_string()           |<C++11 | template&lt; class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a ) const;|
 | &nbsp;                |&nbsp; | &nbsp; |
 | **Literal operator `sv`**|>=C++11| macro `nssv_CONFIG_STD_SV_OPERATOR` |
 | &nbsp;                |&nbsp; | constexpr string_view operator "" **sv**( const char* str, size_t len ) noexcept; |

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -1159,6 +1159,14 @@ to_string( basic_string_view<CharT, Traits> v )
 {
     return std::basic_string<CharT, Traits>( v.begin(), v.end() );
 }
+
+template< class CharT, class Traits, class Allocator >
+std::basic_string<CharT, Traits, Allocator>
+to_string( basic_string_view<CharT, Traits> v, Allocator const & a )
+{
+    return std::basic_string<CharT, Traits, Allocator>( v.begin(), v.end(), a );
+}
+
 #endif // nssv_CPP11_OR_GREATER
 
 template< class CharT, class Traits, class Allocator >

--- a/test/string-view.t.cpp
+++ b/test/string-view.t.cpp
@@ -1171,10 +1171,16 @@ CASE( "to_string(): convert to std::string via to_string() " "[extension]" )
     char hello[] = "hello world";
     string_view sv( hello );
 
-    std::string s = to_string( sv );
+    std::string s1 = to_string( sv );
 
-    EXPECT( sv.size() == s.size() );
-    EXPECT( sv.compare( s ) == 0  );
+    EXPECT( sv.size() == s1.size() );
+    EXPECT( sv.compare( s1 ) == 0  );
+
+    std::string s2 = to_string( sv, std::string::allocator_type() );
+
+    EXPECT( sv.size() == s2.size() );
+    EXPECT( sv.compare( s2 ) == 0  );
+
 #else
     EXPECT( !!"Conversion to/from std::string is not available (nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS=0)." );
 #endif


### PR DESCRIPTION
* Fix doc for >=C++11 `to_string( basic_string_view<CharT, Traits> v, Allocator const & a = Allocator() )`
* Add overload free to_string(Allocator const & a) for lower C++11
* Add new function to readme doc (fix https://github.com/martinmoene/string-view-lite/issues/13)