### PR TITLE
Non-recursive variant of detail::length() for compilers with maximum recursion depth in compile-time constexpr evaluation.

### DIFF
--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -409,6 +409,22 @@ namespace nonstd { namespace sv_lite {
 
 namespace detail {
 
+#if nssv_CPP14_OR_GREATER
+
+template< typename CharT >
+inline constexpr std::size_t length( CharT * s, std::size_t result = 0 )
+{
+    CharT * v = s;
+    std::size_t r = result;
+    while ( *v != '\0' ) {
+       ++v;
+       ++r;
+    }
+    return r;
+}
+
+#else // nssv_CPP14_OR_GREATER
+
 // Expect tail call optimization to make length() non-recursive:
 
 template< typename CharT >
@@ -416,6 +432,8 @@ inline constexpr std::size_t length( CharT * s, std::size_t result = 0 )
 {
     return *s == '\0' ? result : length( s + 1, result + 1 );
 }
+
+#endif // nssv_CPP14_OR_GREATER
 
 } // namespace detail
 


### PR DESCRIPTION
I ran into this in C++14 when creating a string_view with a very long string. For example,

~~~
namespace {
    constexpr ::nonstd::string_view tmp = ::nonstd::string_view(
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
        "01234567890123456789012345678901234567890123456789"
    );
}
~~~

On MSVC 2019 in C++14 mode this gives:

~~~
error C2131: expression did not evaluate to a constant
  note: failure was caused by evaluation exceeding call depth limit of 512 (/constexpr:depth<NUMBER>)
~~~

And on g++ 9.2.1 this gives

~~~
error: ‘constexpr’ evaluation depth exceeds maximum of 512 (use ‘-fconstexpr-depth=’ to increase the maximum)
~~~

I don't think we can fix this for C++11, but when we have C++14 we have better ways to write a constexpr length() of a nullterminated string, so might as well do so to work around this problem.