### PR TITLE
Fix operator== on wstring_view and wchar_t raw string

### DIFF
--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -1010,12 +1010,12 @@ nssv_constexpr bool operator>= (
 template< class CharT, class Traits>
 nssv_constexpr bool operator==(
     basic_string_view<CharT, Traits> lhs,
-    char const * rhs ) nssv_noexcept
+    CharT const * rhs ) nssv_noexcept
 { return lhs.compare( rhs ) == 0; }
 
 template< class CharT, class Traits>
 nssv_constexpr bool operator==(
-    char const * lhs,
+    CharT const * lhs,
     basic_string_view<CharT, Traits> rhs ) nssv_noexcept
 { return rhs.compare( lhs ) == 0; }
 


### PR DESCRIPTION
On VS2015/msvc 14, the operator== can't compare a wstring_view and a wchar_t raw string. This change fix the issue.