### PR TITLE
Enabled compiler builtin use for GCC>6.0; change return type of lengt…

### DIFF
--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -299,7 +299,8 @@ using std::operator<<;
 
 // Presence of compiler intrinsics:
 
-#define nssv_HAVE_BUILTIN_FN    ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_CLANG_VERSION >= 400 || nssv_COMPILER_APPLECLANG_VERSION >= 900 )
+#define nssv_HAVE_BUILTIN_FN    ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_CLANG_VERSION >= 400 \
+                                  || nssv_COMPILER_APPLECLANG_VERSION >= 900 || nssv_COMPILER_GNUC_VERSION >= 600 )
 #define nssv_HAVE_BUILTIN_MEMCMP  nssv_HAVE_BUILTIN_FN
 #define nssv_HAVE_BUILTIN_STRLEN  nssv_HAVE_BUILTIN_FN
 
@@ -448,7 +449,7 @@ inline nssv_constexpr14 int compare( char const * s1, char const * s2, std::size
 
 // specialization of length() for char, see also generic length() further below:
 
-inline nssv_constexpr int length( char const * s )
+inline nssv_constexpr size_t length( char const * s )
 {
     return __builtin_strlen( s );
 }


### PR DESCRIPTION
…h() to match that of __builtin_strlen