### PR TITLE
Fix usage of char type builtins or mem-functions wrt constexpr-ness (#34, thanks to @mcskatkat)

### DIFF
--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -300,23 +300,27 @@ using std::operator<<;
 // Presence of compiler intrinsics:
 
 #define nssv_HAVE_BUILTIN_VER   ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 ||  nssv_COMPILER_CLANG_VERSION >= 400 || nssv_COMPILER_APPLECLANG_VERSION >= 900 )
+#define nssv_HAVE_BUILTIN_CE    ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 ||  nssv_COMPILER_CLANG_VERSION >= 0 || nssv_COMPILER_APPLECLANG_VERSION >= 0 )
+
+#define nssv_HAVE_BUILTIN_MEMCMP_CE  nssv_HAVE_BUILTIN_CE
+#define nssv_HAVE_BUILTIN_STRLEN_CE  nssv_HAVE_BUILTIN_CE
 
 #ifdef __has_builtin
-#define nssv_HAVE_BUILTIN( x )  __has_builtin( x )
+# define nssv_HAVE_BUILTIN( x )  __has_builtin( x )
 #else
-#define nssv_HAVE_BUILTIN( x )  0
+# define nssv_HAVE_BUILTIN( x )  0
 #endif
 
 #if nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
-#define nssv_BUILTIN_MEMCMP  __builtin_memcmp
+# define nssv_BUILTIN_MEMCMP  __builtin_memcmp
 #else
-#define nssv_BUILTIN_MEMCMP  memcmp
+# define nssv_BUILTIN_MEMCMP  memcmp
 #endif
 
 #if nssv_HAVE_BUILTIN(__builtin_strlen) || nssv_HAVE_BUILTIN_VER
-#define nssv_BUILTIN_STRLEN  __builtin_strlen
+# define nssv_BUILTIN_STRLEN  __builtin_strlen
 #else
-#define nssv_BUILTIN_STRLEN  strlen
+# define nssv_BUILTIN_STRLEN  strlen
 #endif
 
 // C++ feature usage:
@@ -449,7 +453,7 @@ inline nssv_constexpr14 int compare( CharT const * s1, CharT const * s2, std::si
     return 0;
 }
 
-#if nssv_HAVE_BUILTIN_MEMCMP
+#if nssv_HAVE_BUILTIN_MEMCMP_CE
 
 // specialization of compare() for char, see also generic compare() above:
 
@@ -460,7 +464,7 @@ inline nssv_constexpr14 int compare( char const * s1, char const * s2, std::size
 
 #endif
 
-#if nssv_HAVE_BUILTIN_STRLEN
+#if nssv_HAVE_BUILTIN_STRLEN_CE
 
 // specialization of length() for char, see also generic length() further below:
 

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -307,13 +307,13 @@ using std::operator<<;
 //
 // | compiler | __builtin_memcmp (constexpr) | memcmp  (constexpr) |
 // |----------|------------------------------|---------------------|
-// | clang    | 4.0              (>= x.y   ) | any     (>= x.y   ) |
-// | clang-a  | 9.0              (>= x.y   ) | any     (>= x.y   ) |
-// | gcc      | any              (>= x.y   ) | any     (>= x.y   ) |
-// | msvc     | >= 14.2          (>= 14.2  ) | any     ( -       ) |
+// | clang    | 4.0              (>= 4.0   ) | any     (?        ) |
+// | clang-a  | 9.0              (>= 9.0   ) | any     (?        ) |
+// | gcc      | any              (constexpr) | any     (?        ) |
+// | msvc     | >= 14.2          (>= 14.2  ) | any     (?        ) |
 
-#define nssv_HAVE_BUILTIN_VER     ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 ||  nssv_COMPILER_CLANG_VERSION >= 400 || nssv_COMPILER_APPLECLANG_VERSION >= 900 )
-#define nssv_HAVE_BUILTIN_CE      ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 ||  nssv_COMPILER_CLANG_VERSION >= 0   || nssv_COMPILER_APPLECLANG_VERSION >= 0 )
+#define nssv_HAVE_BUILTIN_VER     ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 || nssv_COMPILER_CLANG_VERSION >= 400 || nssv_COMPILER_APPLECLANG_VERSION >= 900 )
+#define nssv_HAVE_BUILTIN_CE        nssv_HAVE_BUILTIN_VER
 
 #define nssv_HAVE_BUILTIN_MEMCMP  ( (nssv_HAVE_CONSTEXPR_14 && nssv_HAVE_BUILTIN_CE) || !nssv_HAVE_CONSTEXPR_14 )
 #define nssv_HAVE_BUILTIN_STRLEN  ( (nssv_HAVE_CONSTEXPR_11 && nssv_HAVE_BUILTIN_CE) || !nssv_HAVE_CONSTEXPR_11 )

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -309,14 +309,18 @@ using std::operator<<;
 
 #if nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
 # define nssv_BUILTIN_MEMCMP  __builtin_memcmp
+# define nssv_HAVE_BUILTIN_MEMCMP  1
 #else
 //# define nssv_BUILTIN_MEMCMP  memcmp
+# define nssv_HAVE_BUILTIN_MEMCMP  0
 #endif
 
 #if nssv_HAVE_BUILTIN(__builtin_strlen) || nssv_HAVE_BUILTIN_VER
 # define nssv_BUILTIN_STRLEN  __builtin_strlen
+# define nssv_HAVE_BUILTIN_STRLEN  1
 #else
 //# define nssv_BUILTIN_STRLEN  strlen
+# define nssv_HAVE_BUILTIN_STRLEN  0
 #endif
 
 // C++ feature usage:
@@ -449,7 +453,7 @@ inline nssv_constexpr14 int compare( CharT const * s1, CharT const * s2, std::si
     return 0;
 }
 
-#if nssv_BUILTIN_MEMCMP
+#if nssv_HAVE_BUILTIN_MEMCMP
 
 // specialization of compare() for char, see also generic compare() above:
 
@@ -460,7 +464,7 @@ inline nssv_constexpr14 int compare( char const * s1, char const * s2, std::size
 
 #endif
 
-#if nssv_BUILTIN_STRLEN
+#if nssv_HAVE_BUILTIN_STRLEN
 
 // specialization of length() for char, see also generic length() further below:
 

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -301,6 +301,9 @@ using std::operator<<;
 
 #define nssv_HAVE_BUILTIN_VER   ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 ||  nssv_COMPILER_CLANG_VERSION >= 400 || nssv_COMPILER_APPLECLANG_VERSION >= 900 )
 
+# define nssv_HAVE_BUILTIN_MEMCMP  nssv_HAVE_BUILTIN_VER
+# define nssv_HAVE_BUILTIN_STRLEN  nssv_HAVE_BUILTIN_VER
+
 #ifdef __has_builtin
 # define nssv_HAVE_BUILTIN( x )  __has_builtin( x )
 #else
@@ -309,18 +312,14 @@ using std::operator<<;
 
 #if nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
 # define nssv_BUILTIN_MEMCMP  __builtin_memcmp
-# define nssv_HAVE_BUILTIN_MEMCMP  1
 #else
 //# define nssv_BUILTIN_MEMCMP  memcmp
-# define nssv_HAVE_BUILTIN_MEMCMP  0
 #endif
 
 #if nssv_HAVE_BUILTIN(__builtin_strlen) || nssv_HAVE_BUILTIN_VER
 # define nssv_BUILTIN_STRLEN  __builtin_strlen
-# define nssv_HAVE_BUILTIN_STRLEN  1
 #else
 //# define nssv_BUILTIN_STRLEN  strlen
-# define nssv_HAVE_BUILTIN_STRLEN  0
 #endif
 
 // C++ feature usage:

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -307,19 +307,16 @@ using std::operator<<;
 # define nssv_HAVE_BUILTIN( x )  0
 #endif
 
-#define nssv_HAVE_BUILTIN_MEMCMP   nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
-#define nssv_HAVE_BUILTIN_STRLEN   nssv_HAVE_BUILTIN(__builtin_strlen) || nssv_HAVE_BUILTIN_VER
-
 #if nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
 # define nssv_BUILTIN_MEMCMP  __builtin_memcmp
 #else
-# define nssv_BUILTIN_MEMCMP  memcmp
+//# define nssv_BUILTIN_MEMCMP  memcmp
 #endif
 
 #if nssv_HAVE_BUILTIN(__builtin_strlen) || nssv_HAVE_BUILTIN_VER
 # define nssv_BUILTIN_STRLEN  __builtin_strlen
 #else
-# define nssv_BUILTIN_STRLEN  strlen
+//# define nssv_BUILTIN_STRLEN  strlen
 #endif
 
 // C++ feature usage:
@@ -452,7 +449,7 @@ inline nssv_constexpr14 int compare( CharT const * s1, CharT const * s2, std::si
     return 0;
 }
 
-#if nssv_HAVE_BUILTIN_MEMCMP
+#if nssv_BUILTIN_MEMCMP
 
 // specialization of compare() for char, see also generic compare() above:
 
@@ -463,7 +460,7 @@ inline nssv_constexpr14 int compare( char const * s1, char const * s2, std::size
 
 #endif
 
-#if nssv_HAVE_BUILTIN_STRLEN
+#if nssv_BUILTIN_STRLEN
 
 // specialization of length() for char, see also generic length() further below:
 

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -300,16 +300,15 @@ using std::operator<<;
 // Presence of compiler intrinsics:
 
 #define nssv_HAVE_BUILTIN_VER   ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 ||  nssv_COMPILER_CLANG_VERSION >= 400 || nssv_COMPILER_APPLECLANG_VERSION >= 900 )
-#define nssv_HAVE_BUILTIN_CE    ( nssv_COMPILER_MSVC_VERSION >= 142 || nssv_COMPILER_GNUC_VERSION > 0 ||  nssv_COMPILER_CLANG_VERSION >= 0 || nssv_COMPILER_APPLECLANG_VERSION >= 0 )
-
-#define nssv_HAVE_BUILTIN_MEMCMP_CE  nssv_HAVE_BUILTIN_CE
-#define nssv_HAVE_BUILTIN_STRLEN_CE  nssv_HAVE_BUILTIN_CE
 
 #ifdef __has_builtin
 # define nssv_HAVE_BUILTIN( x )  __has_builtin( x )
 #else
 # define nssv_HAVE_BUILTIN( x )  0
 #endif
+
+#define nssv_HAVE_BUILTIN_MEMCMP   nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
+#define nssv_HAVE_BUILTIN_STRLEN   nssv_HAVE_BUILTIN(__builtin_strlen) || nssv_HAVE_BUILTIN_VER
 
 #if nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
 # define nssv_BUILTIN_MEMCMP  __builtin_memcmp
@@ -453,7 +452,7 @@ inline nssv_constexpr14 int compare( CharT const * s1, CharT const * s2, std::si
     return 0;
 }
 
-#if nssv_HAVE_BUILTIN_MEMCMP_CE
+#if nssv_HAVE_BUILTIN_MEMCMP
 
 // specialization of compare() for char, see also generic compare() above:
 
@@ -464,7 +463,7 @@ inline nssv_constexpr14 int compare( char const * s1, char const * s2, std::size
 
 #endif
 
-#if nssv_HAVE_BUILTIN_STRLEN_CE
+#if nssv_HAVE_BUILTIN_STRLEN
 
 // specialization of length() for char, see also generic length() further below:
 

--- a/test/string-view-main.t.cpp
+++ b/test/string-view-main.t.cpp
@@ -101,6 +101,18 @@ CASE( "presence of C++ library features" "[.stdlibrary]" )
 #endif
 }
 
+CASE( "usage of compiler intrinsics" "[.intrinsics]" )
+{
+#if nssv_USES_STD_STRING_VIEW
+    std::cout << "(Compiler version not available: using std::string_view)\n";
+#else
+    nssv_PRESENT( nssv_HAVE_BUILTIN_VER    );
+    nssv_PRESENT( nssv_HAVE_BUILTIN_CE     );
+    nssv_PRESENT( nssv_HAVE_BUILTIN_MEMCMP );
+    nssv_PRESENT( nssv_HAVE_BUILTIN_STRLEN );
+#endif
+}
+
 int main( int argc, char * argv[] )
 {
     return lest::run( specification(), argc, argv );


### PR DESCRIPTION
Providing char-type specializations for compare() and length() that use compiler intrinsics can improve compile- and run-time performance.

The challenge is in using the right combinations of builtin availablity and its constexpr-ness.