### PR TITLE
added define to build without streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Language](https://img.shields.io/badge/C%2B%2B-98/11/14/17-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization) [![License](https://img.shields.io/badge/license-BSL-blue.svg)](https://opensource.org/licenses/BSL-1.0) [![Build Status](https://travis-ci.org/martinmoene/string-view-lite.svg?branch=master)](https://travis-ci.org/martinmoene/string-view-lite) [![Build status](https://ci.appveyor.com/api/projects/status/1ha3wnxtam547m8p?svg=true)](https://ci.appveyor.com/project/martinmoene/string-view-lite) [![Version](https://badge.fury.io/gh/martinmoene%2Fstring-view-lite.svg)](https://github.com/martinmoene/string-view-lite/releases) [![download](https://img.shields.io/badge/latest-download-blue.svg)](https://github.com/martinmoene/string-view-lite/blob/master/include/nonstd/string_view.hpp) [![Conan](https://img.shields.io/badge/on-conan-blue.svg)](https://bintray.com/conan/conan-center/string-view-lite%3A_) [![Try it on wandbox](https://img.shields.io/badge/on-wandbox-blue.svg)](https://wandbox.org/permlink/ZfX49QqynfuQikTX) [![Try it on godbolt online](https://img.shields.io/badge/on-godbolt-blue.svg)](https://godbolt.org/z/YtxnAn)
 
-**Contents**  
+**Contents**
 
 - [Example usage](#example-usage)
 - [In a nutshell](#in-a-nutshell)
@@ -82,15 +82,15 @@ Or, if you use the [conan package manager](https://www.conan.io/), follow these 
 
 ## Synopsis
 
-**Contents**  
-[Documentation of `std::string_view`](#stdstring_view)  
-[C++20 extensions](#c20-extensions)  
-[Non-standard extensions](#non-standard-extensions)  
-[Configuration](#configuration)    
+**Contents**
+[Documentation of `std::string_view`](#stdstring_view)
+[C++20 extensions](#c20-extensions)
+[Non-standard extensions](#non-standard-extensions)
+[Configuration](#configuration)
 
 ## Documentation of `std::string_view`
 
-Depending on the compiler and C++-standard used, `nonstd::string_view` behaves less or more like `std::string_view`. To get an idea of the capabilities of `nonstd::string_view` with your configuration, look at the output of the [tests](test/string-view.t.cpp), issuing `string-view-lite.t --pass @`. For `std::string_view`, see its [documentation at cppreference](http://en.cppreference.com/w/cpp/string/basic_string_view).  
+Depending on the compiler and C++-standard used, `nonstd::string_view` behaves less or more like `std::string_view`. To get an idea of the capabilities of `nonstd::string_view` with your configuration, look at the output of the [tests](test/string-view.t.cpp), issuing `string-view-lite.t --pass @`. For `std::string_view`, see its [documentation at cppreference](http://en.cppreference.com/w/cpp/string/basic_string_view).
 
 ## C++20 extensions
 
@@ -118,37 +118,37 @@ The literal operators are declared in the namespace `nonstd::literals::string_vi
 
 *string-view lite* can provide several methods and free functions to mimic the cooperation between `std::string` and  `nonstd::string_view` that exists in C++17. See the table below. Several macros allow you to control the presence of these functions, see section [Configuration](#configuration).
 
-| Kind                  | Std   | Function or method |
-|-----------------------|-------|--------------------|
-| **Free functions**    |&nbsp; | macro `nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS`|
-| **`std::string_view`**|&nbsp; | &nbsp; |
-| to_string()           |>=C++17| template&lt; class CharT, class Traits, class Allocator=std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator&gt;<br>**to_string**( std::basic_string_view&lt;CharT, Traits> v, Allocator const & a=Allocator() );|
-| to_string_view()      |>=C++17| template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );|
-| **`nonstd::string_view`**|&nbsp; | &nbsp;  |
-| to_string()<br>&nbsp;<br>*non-msvc14 (vs2015)* |>=C++11| template&lt; class CharT, class Traits, class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a = Allocator() );|
-| to_string()<br>&nbsp;<br>*msvc14 (vs2015)* |<C++11|template&lt; class CharT, class Traits ><br>std::basic_string&lt;CharT, Traits><br>**to_string**( basic_string_view&lt;CharT, Traits> v );|
-| to_string()<br>&nbsp;<br>*msvc14 (vs2015)* |<C++11|template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a );|
-| to_string_view()      |>=C++98| template&lt; class CharT, class Traits, class Allocator ><br>basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );|
-| &nbsp;                |&nbsp; | &nbsp; |
-| **Class methods**     |&nbsp; | macro `nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS` |
-| **`nonstd::basic_string_view`**|&nbsp; |&nbsp; |
-| Constructor           |>=C++98| template&lt; class Allocator ><br>**basic_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s ) nssv_noexcept;|
-| Converting operator   |>=C++11| template&lt; class Allocator ><br>explicit **operator std::basic_string**&lt;CharT, Traits, Allocator>() const;|
-| to_string()           |>=C++11| template&lt; class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a = Allocator() ) const;|
-| to_string()           |<C++11 | std::basic_string&lt;CharT, Traits><br>**to_string**() const;|
-| to_string()           |<C++11 | template&lt; class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a ) const;|
-| &nbsp;                |&nbsp; | &nbsp; |
-| **Literal operator `sv`**|>=C++11| macro `nssv_CONFIG_STD_SV_OPERATOR` |
-| &nbsp;                |&nbsp; | constexpr string_view operator "" **sv**( const char* str, size_t len ) noexcept; |
-| &nbsp;                |&nbsp; | constexpr u16string_view operator "" **sv**( const char16_t* str, size_t len ) noexcept; |
-| &nbsp;                |&nbsp; | constexpr u32string_view operator "" **sv**( const char32_t* str, size_t len ) noexcept; |
-| &nbsp;                |&nbsp; | constexpr wstring_view operator "" **sv**( const wchar_t* str, size_t len ) noexcept; |
-| &nbsp;                |&nbsp; | &nbsp; |
-| **Literal operator `_sv`**|>=C++11| macro `nssv_CONFIG_USR_SV_OPERATOR` |
-| &nbsp;                |&nbsp; | constexpr string_view operator "" **_sv**( const char* str, size_t len ) noexcept; |
-| &nbsp;                |&nbsp; | constexpr u16string_view operator "" **_sv**( const char16_t* str, size_t len ) noexcept; |
-| &nbsp;                |&nbsp; | constexpr u32string_view operator "" **_sv**( const char32_t* str, size_t len ) noexcept; |
-| &nbsp;                |&nbsp; | constexpr wstring_view operator "" **_sv**( const wchar_t* str, size_t len ) noexcept; |
+| Kind                                           | Std     | Function or method                                                                                                                                                                                                                       |
+| ---------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Free functions**                             | &nbsp;  | macro `nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS`                                                                                                                                                                                 |
+| **`std::string_view`**                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
+| to_string()                                    | >=C++17 | template&lt; class CharT, class Traits, class Allocator=std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator&gt;<br>**to_string**( std::basic_string_view&lt;CharT, Traits> v, Allocator const & a=Allocator() ); |
+| to_string_view()                               | >=C++17 | template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );                                                 |
+| **`nonstd::string_view`**                      | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
+| to_string()<br>&nbsp;<br>*non-msvc14 (vs2015)* | >=C++11 | template&lt; class CharT, class Traits, class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a = Allocator() );     |
+| to_string()<br>&nbsp;<br>*msvc14 (vs2015)*     | <C++11  | template&lt; class CharT, class Traits ><br>std::basic_string&lt;CharT, Traits><br>**to_string**( basic_string_view&lt;CharT, Traits> v );                                                                                               |
+| to_string()<br>&nbsp;<br>*msvc14 (vs2015)*     | <C++11  | template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a );                                              |
+| to_string_view()                               | >=C++98 | template&lt; class CharT, class Traits, class Allocator ><br>basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );                                                      |
+| &nbsp;                                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
+| **Class methods**                              | &nbsp;  | macro `nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS`                                                                                                                                                                                  |
+| **`nonstd::basic_string_view`**                | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
+| Constructor                                    | >=C++98 | template&lt; class Allocator ><br>**basic_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s ) nssv_noexcept;                                                                                                       |
+| Converting operator                            | >=C++11 | template&lt; class Allocator ><br>explicit **operator std::basic_string**&lt;CharT, Traits, Allocator>() const;                                                                                                                          |
+| to_string()                                    | >=C++11 | template&lt; class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a = Allocator() ) const;                                                                 |
+| to_string()                                    | <C++11  | std::basic_string&lt;CharT, Traits><br>**to_string**() const;                                                                                                                                                                            |
+| to_string()                                    | <C++11  | template&lt; class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a ) const;                                                                                                          |
+| &nbsp;                                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
+| **Literal operator `sv`**                      | >=C++11 | macro `nssv_CONFIG_STD_SV_OPERATOR`                                                                                                                                                                                                      |
+| &nbsp;                                         | &nbsp;  | constexpr string_view operator "" **sv**( const char* str, size_t len ) noexcept;                                                                                                                                                        |
+| &nbsp;                                         | &nbsp;  | constexpr u16string_view operator "" **sv**( const char16_t* str, size_t len ) noexcept;                                                                                                                                                 |
+| &nbsp;                                         | &nbsp;  | constexpr u32string_view operator "" **sv**( const char32_t* str, size_t len ) noexcept;                                                                                                                                                 |
+| &nbsp;                                         | &nbsp;  | constexpr wstring_view operator "" **sv**( const wchar_t* str, size_t len ) noexcept;                                                                                                                                                    |
+| &nbsp;                                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
+| **Literal operator `_sv`**                     | >=C++11 | macro `nssv_CONFIG_USR_SV_OPERATOR`                                                                                                                                                                                                      |
+| &nbsp;                                         | &nbsp;  | constexpr string_view operator "" **_sv**( const char* str, size_t len ) noexcept;                                                                                                                                                       |
+| &nbsp;                                         | &nbsp;  | constexpr u16string_view operator "" **_sv**( const char16_t* str, size_t len ) noexcept;                                                                                                                                                |
+| &nbsp;                                         | &nbsp;  | constexpr u32string_view operator "" **_sv**( const char32_t* str, size_t len ) noexcept;                                                                                                                                                |
+| &nbsp;                                         | &nbsp;  | constexpr wstring_view operator "" **_sv**( const wchar_t* str, size_t len ) noexcept;                                                                                                                                                   |
 
 ## Configuration
 
@@ -158,14 +158,14 @@ If the compiler supports [`__has_include()`](https://en.cppreference.com/w/cpp/p
 
 ### Standard selection macro
 
-\-D<b>nssv\_CPLUSPLUS</b>=199711L  
+\-D<b>nssv\_CPLUSPLUS</b>=199711L
 Define this macro to override the auto-detection of the supported C++ standard, if your compiler does not set the `__cpluplus` macro correctly.
 
 ### Select `std::string_view` or `nonstd::string_view`
 
 At default, *string-view lite* uses `std::string_view` if it is available and lets you use it via namespace `nonstd`. You can however override this default and explicitly request to use `std::string_view` as `nonstd::string_view` or use string-view lite's `nonstd::string_view` via the following macros.
 
--D<b>nssv\_CONFIG\_SELECT\_STRING_VIEW</b>=nssv_STRING_VIEW_DEFAULT  
+-D<b>nssv\_CONFIG\_SELECT\_STRING_VIEW</b>=nssv_STRING_VIEW_DEFAULT
 Define this to `nssv_STRING_VIEW_STD` to select `std::string_view` as `nonstd::string_view`. Define this to `nssv_STRING_VIEW_NONSTD` to select `nonstd::string_view` as `nonstd::string_view`. Default is undefined, which has the same effect as defining to `nssv_STRING_VIEW_DEFAULT`.
 
 Note: <b>nssv_CONFIG_SELECT_STD_STRING_VIEW</b> and <b>nssv_CONFIG_SELECT_NONSTD_STRING_VIEW</b> are deprecated and have been removed.
@@ -177,37 +177,47 @@ Define this to 1 if you want to compile without exceptions. If not defined, the 
 
 ### Add or omit literal operators `sv` and `_sv`
 
--D<b>nssv_CONFIG_STD_SV_OPERATOR</b>=1  
+-D<b>nssv_CONFIG_STD_SV_OPERATOR</b>=1
 Define this to 1 to provide literal operator `sv` to create a `string_view` from a literal string. Default is 0. Note that literal operators without leading underscore are reserved for the C++ standard.
 
--D<b>nssv_CONFIG_USR_SV_OPERATOR</b>=0  
+-D<b>nssv_CONFIG_USR_SV_OPERATOR</b>=0
 Define this to 0 to omit literal operator `_sv` to create a `string_view` from a literal string. Default is 1.
 
 ### Omit cooperation between `std::string`&ndash;`nonstd::string_view`
 
 At default, *string-view lite* provides several methods and free functions to mimic the cooperation between `std::string` and  `nonstd::string_view` (or `std::string_view`) that exists in C++17. See section [Non-standard extensions](#non-standard-extensions). The following macros allow you to control the presence of these functions.
- 
--D<b>nssv_CONFIG_CONVERSION_STD_STRING</b>=1  
+
+-D<b>nssv_CONFIG_CONVERSION_STD_STRING</b>=1
 Define this to 1 to provide `std::string`&ndash; `nonstd::string_view` interoperability via methods of `nonstd::basic_string_view` and free functions, define it to 0 to omit all said methods and functions. Default is undefined.
 
--D<b>nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS</b>=1  
+-D<b>nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS</b>=1
 Define this to 1 to provide `std::string`&ndash; `nonstd::string_view` interoperability via methods of `nonstd::basic_string_view`, define it to 0 to omit all said methods. Default is undefined.
 
--D<b>nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS</b>=1  
+-D<b>nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS</b>=1
 Define this to 1 to provide `std::string`&ndash; `nonstd::string_view` interoperability via free functions, define it to 0 to omit all said functions. This also controls the presence of these function if `std::string_view` is used. Default is undefined.
+
+### Omit use of streams
+
+At defaults, *string-view lite* provides operations to overload the
+`operator<<`.
+If you want to use the library without the use of standard streams,
+you can control this withtThe following macro:
+
+-D<b>nssv_CONFIG_NO_STREAM_INSERTION</b>=1
+Define this to 1 to omit the use of standard streams. Default is undefined
 
 ## Reported to work with
 
 The table below mentions the compiler versions *string-view lite* is reported to work with.
 
-OS        | Compiler   | Versions |
----------:|:-----------|:---------|
-Windows   | Clang/LLVM | ?        |
-&nbsp;    | GCC        | 7.2.0    |
-&nbsp;    | Visual C++<br>(Visual Studio)| 8 (2005), 9 (2008), 10 (2010), 11 (2012),<br>12 (2013), 14 (2015), 15 (2017) |
-GNU/Linux | Clang/LLVM | 3.5 - 6.0  |
-&nbsp;    | GCC        | 4.8 - 8 |
-OS X      | Clang/LLVM | Xcode 6, Xcode 7, Xcode 8, Xcode 9 |
+|        OS | Compiler                      | Versions                                                                     |
+| --------: | :---------------------------- | :--------------------------------------------------------------------------- |
+|   Windows | Clang/LLVM                    | ?                                                                            |
+|    &nbsp; | GCC                           | 7.2.0                                                                        |
+|    &nbsp; | Visual C++<br>(Visual Studio) | 8 (2005), 9 (2008), 10 (2010), 11 (2012),<br>12 (2013), 14 (2015), 15 (2017) |
+| GNU/Linux | Clang/LLVM                    | 3.5 - 6.0                                                                    |
+|    &nbsp; | GCC                           | 4.8 - 8                                                                      |
+|      OS X | Clang/LLVM                    | Xcode 6, Xcode 7, Xcode 8, Xcode 9                                           |
 
 ## Building the tests
 
@@ -231,11 +241,11 @@ Here we use c:\string-view-lite\build-win-x86-vc10.
 
         cmake -G "Visual Studio 10 2010" -DSTRING_VIEW_LITE_OPT_BUILD_TESTS=ON ..
 
-3. Build the test suite in the Debug configuration (alternatively use Release).    
+3. Build the test suite in the Debug configuration (alternatively use Release).
 
         cmake --build . --config Debug
 
-4. Run the test suite.    
+4. Run the test suite.
 
         ctest -V -C Debug
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Language](https://img.shields.io/badge/C%2B%2B-98/11/14/17-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization) [![License](https://img.shields.io/badge/license-BSL-blue.svg)](https://opensource.org/licenses/BSL-1.0) [![Build Status](https://travis-ci.org/martinmoene/string-view-lite.svg?branch=master)](https://travis-ci.org/martinmoene/string-view-lite) [![Build status](https://ci.appveyor.com/api/projects/status/1ha3wnxtam547m8p?svg=true)](https://ci.appveyor.com/project/martinmoene/string-view-lite) [![Version](https://badge.fury.io/gh/martinmoene%2Fstring-view-lite.svg)](https://github.com/martinmoene/string-view-lite/releases) [![download](https://img.shields.io/badge/latest-download-blue.svg)](https://github.com/martinmoene/string-view-lite/blob/master/include/nonstd/string_view.hpp) [![Conan](https://img.shields.io/badge/on-conan-blue.svg)](https://bintray.com/conan/conan-center/string-view-lite%3A_) [![Try it on wandbox](https://img.shields.io/badge/on-wandbox-blue.svg)](https://wandbox.org/permlink/ZfX49QqynfuQikTX) [![Try it on godbolt online](https://img.shields.io/badge/on-godbolt-blue.svg)](https://godbolt.org/z/YtxnAn)
 
-**Contents**
+**Contents**  
 
 - [Example usage](#example-usage)
 - [In a nutshell](#in-a-nutshell)
@@ -82,15 +82,15 @@ Or, if you use the [conan package manager](https://www.conan.io/), follow these 
 
 ## Synopsis
 
-**Contents**
-[Documentation of `std::string_view`](#stdstring_view)
-[C++20 extensions](#c20-extensions)
-[Non-standard extensions](#non-standard-extensions)
-[Configuration](#configuration)
+**Contents**  
+[Documentation of `std::string_view`](#stdstring_view)  
+[C++20 extensions](#c20-extensions)  
+[Non-standard extensions](#non-standard-extensions)  
+[Configuration](#configuration)    
 
 ## Documentation of `std::string_view`
 
-Depending on the compiler and C++-standard used, `nonstd::string_view` behaves less or more like `std::string_view`. To get an idea of the capabilities of `nonstd::string_view` with your configuration, look at the output of the [tests](test/string-view.t.cpp), issuing `string-view-lite.t --pass @`. For `std::string_view`, see its [documentation at cppreference](http://en.cppreference.com/w/cpp/string/basic_string_view).
+Depending on the compiler and C++-standard used, `nonstd::string_view` behaves less or more like `std::string_view`. To get an idea of the capabilities of `nonstd::string_view` with your configuration, look at the output of the [tests](test/string-view.t.cpp), issuing `string-view-lite.t --pass @`. For `std::string_view`, see its [documentation at cppreference](http://en.cppreference.com/w/cpp/string/basic_string_view).  
 
 ## C++20 extensions
 
@@ -158,14 +158,14 @@ If the compiler supports [`__has_include()`](https://en.cppreference.com/w/cpp/p
 
 ### Standard selection macro
 
-\-D<b>nssv\_CPLUSPLUS</b>=199711L
+\-D<b>nssv\_CPLUSPLUS</b>=199711L  
 Define this macro to override the auto-detection of the supported C++ standard, if your compiler does not set the `__cpluplus` macro correctly.
 
 ### Select `std::string_view` or `nonstd::string_view`
 
 At default, *string-view lite* uses `std::string_view` if it is available and lets you use it via namespace `nonstd`. You can however override this default and explicitly request to use `std::string_view` as `nonstd::string_view` or use string-view lite's `nonstd::string_view` via the following macros.
 
--D<b>nssv\_CONFIG\_SELECT\_STRING_VIEW</b>=nssv_STRING_VIEW_DEFAULT
+-D<b>nssv\_CONFIG\_SELECT\_STRING_VIEW</b>=nssv_STRING_VIEW_DEFAULT  
 Define this to `nssv_STRING_VIEW_STD` to select `std::string_view` as `nonstd::string_view`. Define this to `nssv_STRING_VIEW_NONSTD` to select `nonstd::string_view` as `nonstd::string_view`. Default is undefined, which has the same effect as defining to `nssv_STRING_VIEW_DEFAULT`.
 
 Note: <b>nssv_CONFIG_SELECT_STD_STRING_VIEW</b> and <b>nssv_CONFIG_SELECT_NONSTD_STRING_VIEW</b> are deprecated and have been removed.
@@ -177,23 +177,23 @@ Define this to 1 if you want to compile without exceptions. If not defined, the 
 
 ### Add or omit literal operators `sv` and `_sv`
 
--D<b>nssv_CONFIG_STD_SV_OPERATOR</b>=1
+-D<b>nssv_CONFIG_STD_SV_OPERATOR</b>=1  
 Define this to 1 to provide literal operator `sv` to create a `string_view` from a literal string. Default is 0. Note that literal operators without leading underscore are reserved for the C++ standard.
 
--D<b>nssv_CONFIG_USR_SV_OPERATOR</b>=0
+-D<b>nssv_CONFIG_USR_SV_OPERATOR</b>=0  
 Define this to 0 to omit literal operator `_sv` to create a `string_view` from a literal string. Default is 1.
 
 ### Omit cooperation between `std::string`&ndash;`nonstd::string_view`
 
 At default, *string-view lite* provides several methods and free functions to mimic the cooperation between `std::string` and  `nonstd::string_view` (or `std::string_view`) that exists in C++17. See section [Non-standard extensions](#non-standard-extensions). The following macros allow you to control the presence of these functions.
-
--D<b>nssv_CONFIG_CONVERSION_STD_STRING</b>=1
+ 
+-D<b>nssv_CONFIG_CONVERSION_STD_STRING</b>=1  
 Define this to 1 to provide `std::string`&ndash; `nonstd::string_view` interoperability via methods of `nonstd::basic_string_view` and free functions, define it to 0 to omit all said methods and functions. Default is undefined.
 
--D<b>nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS</b>=1
+-D<b>nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS</b>=1  
 Define this to 1 to provide `std::string`&ndash; `nonstd::string_view` interoperability via methods of `nonstd::basic_string_view`, define it to 0 to omit all said methods. Default is undefined.
 
--D<b>nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS</b>=1
+-D<b>nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS</b>=1  
 Define this to 1 to provide `std::string`&ndash; `nonstd::string_view` interoperability via free functions, define it to 0 to omit all said functions. This also controls the presence of these function if `std::string_view` is used. Default is undefined.
 
 ### Omit use of streams
@@ -241,11 +241,11 @@ Here we use c:\string-view-lite\build-win-x86-vc10.
 
         cmake -G "Visual Studio 10 2010" -DSTRING_VIEW_LITE_OPT_BUILD_TESTS=ON ..
 
-3. Build the test suite in the Debug configuration (alternatively use Release).
+3. Build the test suite in the Debug configuration (alternatively use Release).    
 
         cmake --build . --config Debug
 
-4. Run the test suite.
+4. Run the test suite.    
 
         ctest -V -C Debug
 

--- a/README.md
+++ b/README.md
@@ -118,37 +118,37 @@ The literal operators are declared in the namespace `nonstd::literals::string_vi
 
 *string-view lite* can provide several methods and free functions to mimic the cooperation between `std::string` and  `nonstd::string_view` that exists in C++17. See the table below. Several macros allow you to control the presence of these functions, see section [Configuration](#configuration).
 
-| Kind                                           | Std     | Function or method                                                                                                                                                                                                                       |
-| ---------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Free functions**                             | &nbsp;  | macro `nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS`                                                                                                                                                                                 |
-| **`std::string_view`**                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
-| to_string()                                    | >=C++17 | template&lt; class CharT, class Traits, class Allocator=std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator&gt;<br>**to_string**( std::basic_string_view&lt;CharT, Traits> v, Allocator const & a=Allocator() ); |
-| to_string_view()                               | >=C++17 | template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );                                                 |
-| **`nonstd::string_view`**                      | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
-| to_string()<br>&nbsp;<br>*non-msvc14 (vs2015)* | >=C++11 | template&lt; class CharT, class Traits, class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a = Allocator() );     |
-| to_string()<br>&nbsp;<br>*msvc14 (vs2015)*     | <C++11  | template&lt; class CharT, class Traits ><br>std::basic_string&lt;CharT, Traits><br>**to_string**( basic_string_view&lt;CharT, Traits> v );                                                                                               |
-| to_string()<br>&nbsp;<br>*msvc14 (vs2015)*     | <C++11  | template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a );                                              |
-| to_string_view()                               | >=C++98 | template&lt; class CharT, class Traits, class Allocator ><br>basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );                                                      |
-| &nbsp;                                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
-| **Class methods**                              | &nbsp;  | macro `nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS`                                                                                                                                                                                  |
-| **`nonstd::basic_string_view`**                | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
-| Constructor                                    | >=C++98 | template&lt; class Allocator ><br>**basic_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s ) nssv_noexcept;                                                                                                       |
-| Converting operator                            | >=C++11 | template&lt; class Allocator ><br>explicit **operator std::basic_string**&lt;CharT, Traits, Allocator>() const;                                                                                                                          |
-| to_string()                                    | >=C++11 | template&lt; class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a = Allocator() ) const;                                                                 |
-| to_string()                                    | <C++11  | std::basic_string&lt;CharT, Traits><br>**to_string**() const;                                                                                                                                                                            |
-| to_string()                                    | <C++11  | template&lt; class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a ) const;                                                                                                          |
-| &nbsp;                                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
-| **Literal operator `sv`**                      | >=C++11 | macro `nssv_CONFIG_STD_SV_OPERATOR`                                                                                                                                                                                                      |
-| &nbsp;                                         | &nbsp;  | constexpr string_view operator "" **sv**( const char* str, size_t len ) noexcept;                                                                                                                                                        |
-| &nbsp;                                         | &nbsp;  | constexpr u16string_view operator "" **sv**( const char16_t* str, size_t len ) noexcept;                                                                                                                                                 |
-| &nbsp;                                         | &nbsp;  | constexpr u32string_view operator "" **sv**( const char32_t* str, size_t len ) noexcept;                                                                                                                                                 |
-| &nbsp;                                         | &nbsp;  | constexpr wstring_view operator "" **sv**( const wchar_t* str, size_t len ) noexcept;                                                                                                                                                    |
-| &nbsp;                                         | &nbsp;  | &nbsp;                                                                                                                                                                                                                                   |
-| **Literal operator `_sv`**                     | >=C++11 | macro `nssv_CONFIG_USR_SV_OPERATOR`                                                                                                                                                                                                      |
-| &nbsp;                                         | &nbsp;  | constexpr string_view operator "" **_sv**( const char* str, size_t len ) noexcept;                                                                                                                                                       |
-| &nbsp;                                         | &nbsp;  | constexpr u16string_view operator "" **_sv**( const char16_t* str, size_t len ) noexcept;                                                                                                                                                |
-| &nbsp;                                         | &nbsp;  | constexpr u32string_view operator "" **_sv**( const char32_t* str, size_t len ) noexcept;                                                                                                                                                |
-| &nbsp;                                         | &nbsp;  | constexpr wstring_view operator "" **_sv**( const wchar_t* str, size_t len ) noexcept;                                                                                                                                                   |
+| Kind                  | Std   | Function or method |
+|-----------------------|-------|--------------------|
+| **Free functions**    |&nbsp; | macro `nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS`|
+| **`std::string_view`**|&nbsp; | &nbsp; |
+| to_string()           |>=C++17| template&lt; class CharT, class Traits, class Allocator=std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator&gt;<br>**to_string**( std::basic_string_view&lt;CharT, Traits> v, Allocator const & a=Allocator() );|
+| to_string_view()      |>=C++17| template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );|
+| **`nonstd::string_view`**|&nbsp; | &nbsp;  |
+| to_string()<br>&nbsp;<br>*non-msvc14 (vs2015)* |>=C++11| template&lt; class CharT, class Traits, class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a = Allocator() );|
+| to_string()<br>&nbsp;<br>*msvc14 (vs2015)* |<C++11|template&lt; class CharT, class Traits ><br>std::basic_string&lt;CharT, Traits><br>**to_string**( basic_string_view&lt;CharT, Traits> v );|
+| to_string()<br>&nbsp;<br>*msvc14 (vs2015)* |<C++11|template&lt; class CharT, class Traits, class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( basic_string_view&lt;CharT, Traits> v, Allocator const & a );|
+| to_string_view()      |>=C++98| template&lt; class CharT, class Traits, class Allocator ><br>basic_string_view&lt;CharT, Traits><br>**to_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s );|
+| &nbsp;                |&nbsp; | &nbsp; |
+| **Class methods**     |&nbsp; | macro `nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS` |
+| **`nonstd::basic_string_view`**|&nbsp; |&nbsp; |
+| Constructor           |>=C++98| template&lt; class Allocator ><br>**basic_string_view**( std::basic_string&lt;CharT, Traits, Allocator> const & s ) nssv_noexcept;|
+| Converting operator   |>=C++11| template&lt; class Allocator ><br>explicit **operator std::basic_string**&lt;CharT, Traits, Allocator>() const;|
+| to_string()           |>=C++11| template&lt; class Allocator = std::allocator&lt;CharT> ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a = Allocator() ) const;|
+| to_string()           |<C++11 | std::basic_string&lt;CharT, Traits><br>**to_string**() const;|
+| to_string()           |<C++11 | template&lt; class Allocator ><br>std::basic_string&lt;CharT, Traits, Allocator><br>**to_string**( Allocator const & a ) const;|
+| &nbsp;                |&nbsp; | &nbsp; |
+| **Literal operator `sv`**|>=C++11| macro `nssv_CONFIG_STD_SV_OPERATOR` |
+| &nbsp;                |&nbsp; | constexpr string_view operator "" **sv**( const char* str, size_t len ) noexcept; |
+| &nbsp;                |&nbsp; | constexpr u16string_view operator "" **sv**( const char16_t* str, size_t len ) noexcept; |
+| &nbsp;                |&nbsp; | constexpr u32string_view operator "" **sv**( const char32_t* str, size_t len ) noexcept; |
+| &nbsp;                |&nbsp; | constexpr wstring_view operator "" **sv**( const wchar_t* str, size_t len ) noexcept; |
+| &nbsp;                |&nbsp; | &nbsp; |
+| **Literal operator `_sv`**|>=C++11| macro `nssv_CONFIG_USR_SV_OPERATOR` |
+| &nbsp;                |&nbsp; | constexpr string_view operator "" **_sv**( const char* str, size_t len ) noexcept; |
+| &nbsp;                |&nbsp; | constexpr u16string_view operator "" **_sv**( const char16_t* str, size_t len ) noexcept; |
+| &nbsp;                |&nbsp; | constexpr u32string_view operator "" **_sv**( const char32_t* str, size_t len ) noexcept; |
+| &nbsp;                |&nbsp; | constexpr wstring_view operator "" **_sv**( const wchar_t* str, size_t len ) noexcept; |
 
 ## Configuration
 
@@ -210,14 +210,14 @@ Define this to 1 to omit the use of standard streams. Default is undefined
 
 The table below mentions the compiler versions *string-view lite* is reported to work with.
 
-|        OS | Compiler                      | Versions                                                                     |
-| --------: | :---------------------------- | :--------------------------------------------------------------------------- |
-|   Windows | Clang/LLVM                    | ?                                                                            |
-|    &nbsp; | GCC                           | 7.2.0                                                                        |
-|    &nbsp; | Visual C++<br>(Visual Studio) | 8 (2005), 9 (2008), 10 (2010), 11 (2012),<br>12 (2013), 14 (2015), 15 (2017) |
-| GNU/Linux | Clang/LLVM                    | 3.5 - 6.0                                                                    |
-|    &nbsp; | GCC                           | 4.8 - 8                                                                      |
-|      OS X | Clang/LLVM                    | Xcode 6, Xcode 7, Xcode 8, Xcode 9                                           |
+OS        | Compiler   | Versions |
+---------:|:-----------|:---------|
+Windows   | Clang/LLVM | ?        |
+&nbsp;    | GCC        | 7.2.0    |
+&nbsp;    | Visual C++<br>(Visual Studio)| 8 (2005), 9 (2008), 10 (2010), 11 (2012),<br>12 (2013), 14 (2015), 15 (2017) |
+GNU/Linux | Clang/LLVM | 3.5 - 6.0  |
+&nbsp;    | GCC        | 4.8 - 8 |
+OS X      | Clang/LLVM | Xcode 6, Xcode 7, Xcode 8, Xcode 9 |
 
 ## Building the tests
 

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -408,9 +408,9 @@ using std::operator<<;
 #include <cassert>
 #include <iterator>
 #include <limits>
-#if !defined(nssv_NO_STREAM)
+#if !defined(nssv_CONFIG_NO_STREAM_INSERTION)
 #include<ostream>
-#endif //nssv_NO_STREAM
+#endif //nssv_CONFIG_NO_STREAM_INSERTION
 #include <string>   // std::char_traits<>
 
 #if ! nssv_CONFIG_NO_EXCEPTIONS
@@ -1359,7 +1359,7 @@ nssv_constexpr bool operator>= (
 
 #endif // compiler-dependent approach to comparisons
 
-#if !defined(nssv_NO_STREAM)
+#if !defined(nssv_CONFIG_NO_STREAM_INSERTION)
 // 24.4.4 Inserters and extractors:
 
 namespace detail {
@@ -1410,7 +1410,7 @@ operator<<(
 {
     return detail::write_to_stream( os, sv );
 }
-#endif // nssv_NO_STREAM
+#endif // nssv_CONFIG_NO_STREAM_INSERTION
 // Several typedefs for common character types are provided:
 
 typedef basic_string_view<char>      string_view;
@@ -1559,9 +1559,9 @@ using sv_lite::operator<=;
 using sv_lite::operator>;
 using sv_lite::operator>=;
 
-#if !defined(nssv_NO_STREAM)
+#if !defined(nssv_CONFIG_NO_STREAM_INSERTION)
 using sv_lite::operator<<;
-#endif // nssv_NO_STREAM
+#endif // nssv_CONFIG_NO_STREAM_INSERTION
 
 #if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
 using sv_lite::to_string;

--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -408,7 +408,9 @@ using std::operator<<;
 #include <cassert>
 #include <iterator>
 #include <limits>
-#include <ostream>
+#if !defined(nssv_NO_STREAM)
+#include<ostream>
+#endif //nssv_NO_STREAM
 #include <string>   // std::char_traits<>
 
 #if ! nssv_CONFIG_NO_EXCEPTIONS
@@ -1357,6 +1359,7 @@ nssv_constexpr bool operator>= (
 
 #endif // compiler-dependent approach to comparisons
 
+#if !defined(nssv_NO_STREAM)
 // 24.4.4 Inserters and extractors:
 
 namespace detail {
@@ -1407,7 +1410,7 @@ operator<<(
 {
     return detail::write_to_stream( os, sv );
 }
-
+#endif // nssv_NO_STREAM
 // Several typedefs for common character types are provided:
 
 typedef basic_string_view<char>      string_view;
@@ -1556,7 +1559,9 @@ using sv_lite::operator<=;
 using sv_lite::operator>;
 using sv_lite::operator>=;
 
+#if !defined(nssv_NO_STREAM)
 using sv_lite::operator<<;
+#endif // nssv_NO_STREAM
 
 #if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
 using sv_lite::to_string;

--- a/test/string-view.t.cpp
+++ b/test/string-view.t.cpp
@@ -1060,6 +1060,7 @@ CASE( "string_view: Allows to compare empty string_view-s as equal via compare()
 
 CASE ( "operator<<: Allows printing a string_view to an output stream" )
 {
+#if !defined(nssv_CONFIG_NO_STREAM_INSERTION)
     std::ostringstream oss;
     char s[] = "hello";
     string_view sv( s );
@@ -1070,6 +1071,9 @@ CASE ( "operator<<: Allows printing a string_view to an output stream" )
         << std::setfill('.') << std::left << std::setw(10) << sv;
 
     EXPECT( oss.str() == "hello\n     hello\nhello\nhello....." );
+#else
+    EXPECT( !!"standard streams are not available (nssv_CONFIG_NO_STREAM_INSERTION is defined)" );
+#endif
 }
 
 // 24.4.5 Hash support (C++11):


### PR DESCRIPTION
Hello! Thanks for your great library.

I need to use your library in an Intel SGX Enclave where we can't use standard streams (for security reasons).

In order to use your library I needed to exclude those lines from the header