### PR TITLE
silence compiler warnings for gcc 4.7 and before

### DIFF
--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -435,8 +435,10 @@ using std::operator<<;
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wuser-defined-literals"
 #elif defined(__GNUC__)
-# pragma  GCC  diagnostic push
-# pragma  GCC  diagnostic ignored "-Wliteral-suffix"
+# if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408
+#  pragma  GCC  diagnostic push
+#  pragma  GCC  diagnostic ignored "-Wliteral-suffix"
+# endif
 #endif // __clang__
 
 #if nssv_COMPILER_MSVC_VERSION >= 140
@@ -452,7 +454,11 @@ using std::operator<<;
 #if defined(__clang__)
 # define nssv_RESTORE_WARNINGS()  _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__)
-# define nssv_RESTORE_WARNINGS()  _Pragma("GCC diagnostic pop")
+# if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408
+#  define nssv_RESTORE_WARNINGS()  _Pragma("GCC diagnostic pop")
+# else
+#  define nssv_RESTORE_WARNINGS()
+# endif
 #elif nssv_COMPILER_MSVC_VERSION >= 140
 # define nssv_RESTORE_WARNINGS()  __pragma(warning(pop ))
 #else


### PR DESCRIPTION
The option -Wliteral-suffix was introduced in gcc 4.8, and ```#pragma GCC diagnostic push``` was added in 4.6. Using the header with an older gcc would lead to warnings like:

```
string_view.hpp:438: warning: expected [error|warning|ignored] after '#pragma GCC diagnostic'
string_view.hpp:439: warning: unknown option after '#pragma GCC diagnostic' kind
string_view.hpp:1681: warning: expected [error|warning|ignored] after '#pragma GCC diagnostic'
```
