### PR TITLE
fix build with gcc 4.9 as the first version of find() can't be constexpr then

### DIFF
--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -845,7 +845,7 @@ public:
 
     // find(), 4x:
 
-    nssv_constexpr size_type find( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    nssv_constexpr14 size_type find( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
     {
         return assert( v.size() == 0 || v.data() != nssv_nullptr )
             , pos >= size()


### PR DESCRIPTION
The build error is:

```
  string_view.hpp:859:5: error: body of constexpr function 'constexpr nonstd::sv_lite::basic_string_view<CharT, Traits>::size_type nonstd::sv_lite::basic_string_view<CharT, Traits>::find(nonstd::sv_lite::basic_string_view<CharT, Traits>, nonstd::sv_lite::basic_string_view<CharT, Traits>::size_type) const [with CharT = char; Traits = std::char_traits<char>; nonstd::sv_lite::basic_string_view<CharT, Traits>::size_type = unsigned int]' not a return-statement
```