### PR TITLE
Include `<string>` before using `std::basic_string`

### DIFF
--- a/include/nonstd/string_view.hpp
+++ b/include/nonstd/string_view.hpp
@@ -134,6 +134,8 @@
 
 #if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
 
+#include <string>
+
 namespace nonstd {
 
 template< class CharT, class Traits, class Allocator = std::allocator<CharT> >


### PR DESCRIPTION
I work on MSVC's STL, and we regularly build popular open-source projects, including yours, with development builds of the MSVC toolset. This allows us to find and fix toolset regressions before they affect users, and also allows us to provide advance notice of breaking changes, which is the case here.

We recently merged https://github.com/microsoft/STL/pull/4633 which will ship in VS 2022 17.11 Preview 3. This improved build throughput by refactoring `<string_view>` so that it no longer drags in `std::basic_string`. It's also a source-breaking change for code that wasn't properly including `<string>`.

Your `include/nonstd/string_view.hpp` has an "early" use of `std::basic_string` that isn't preceded by `#include <string>`. When built with our updated STL, this will emit a compiler `error C2039: 'basic_string': is not a member of 'std'`. The fix is simple and portable: simply include the necessary header, immediately before it's needed.

I checked the rest of your header, and all following mentions of `std::basic_string` further down in the file appear to be correctly preceded by `#include <string>`.