### PR TITLE
Add workflow for Clang 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,43 @@ jobs:
         working-directory: build
         run: ctest --output-on-failure -j 4
 
+  clang_in_container:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: 20
+            image: 'ubuntu:25.04'
+
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clang ${{ matrix.version }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update && apt-get upgrade -y
+          apt-get install -y clang-${{ matrix.version }} cmake
+
+      - name: Configure tests
+        env:
+          CXX: clang++-${{ matrix.version }}
+        run: cmake -S . -B build
+          -D CMAKE_CXX_COMPILER=clang++-${{ matrix.version }}
+          -D CMAKE_BUILD_TYPE:STRING=Release
+          -D ${{ env.PROJECT }}_OPT_SELECT_NONSTD=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_TESTS=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_EXAMPLES=OFF
+
+      - name: Build tests
+        run: cmake --build build -j 4
+
+      - name: Run tests
+        working-directory: build
+        run: ctest --output-on-failure -j 4
+
   msvc:
     strategy:
       fail-fast: false


### PR DESCRIPTION
The pull requests adds an experimental workflow for Clang 20, currently the newest major release for Clang.

Clang 20 is not available on the `ubuntu-24.04` or `ubuntu-22.04` runner images provided by GitHub Actions, so the workflow uses the Docker image for the newer Ubuntu 25.04 release instead. Packages for Clang 20 are available there. The final release of Ubuntu 25.04 (codenamed "Plucky Puffin") is expected to occur on 2025-04-17, in approximately a month from now. However, according to [its release schedule](https://discourse.ubuntu.com/t/plucky-puffin-release-schedule/36461) the feature freeze took place in February. That means no new packages are introduced after that and we can be sure that the [clang-20 package](https://packages.ubuntu.com/plucky/clang-20) currently available will also be available in the final release.

This is a proof of concept to show that even compiler versions which are not directly/easily available on the existing GitHub Actions runner images can be run and used for builds and tests when using other Docker images, as previously mentioned [here](https://github.com/martinmoene/nonstd-lite-project/issues/75#issuecomment-2735170322).


A bit of explanation for the workflow syntax:
* The main difference to the usual Clang workflow is that this one uses the [`container`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainer) option to specify the image for a Docker container to run the workflow steps in. So the part
  ```
    runs-on: ubuntu-latest
    container: ${{ matrix.image }}
  ```
  means that the job itself runs on the `ubuntu-latest` runner image (currently `ubuntu-24.04`), but within that runner it starts a Docker container using the Docker image specified in `${{ matrix.image }}` - which is `ubuntu:25.04` in this case. See the matrix a few lines above.
* Installation commands for the packages are changed from `sudo apt-get install ...` to just `apt-get install ...`, because there's no `sudo` inside the Docker container.
* CMake has to be installed explicitly, too, because it's not available by default in the `ubuntu:25.04` Docker image.
* The `export DEBIAN_FRONTEND=noninteractive` line is there to make sure that any potential interactive dialog choices during package updates and installation get skipped. The [documentation](https://manpages.ubuntu.com/manpages/plucky/man7/debconf.7.html#frontends) says:
  > ```
  > noninteractive
  >        This  is  the  anti-frontend. It never interacts with you at all, and makes the default answers be
  >        used for all questions. It might mail error messages to root,  but  that's  it;  otherwise  it  is
  >        completely  silent  and  unobtrusive,  a perfect frontend for automatic installs. [...]
  > ```

Basically, that's all there is to it. Build and test commands are the same as for the "normal" Clang workflows.

If there are any more questions about the workflow, feel free to ask.